### PR TITLE
Fix auto-tag workflow permissions

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   tag:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
- Add contents: write permission to allow pushing tags
- This allows the workflow to create and push tags to trigger the publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)