### PR TITLE
ci: pin publish workflow to Node 22 (undici regression fix)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24.x'
+          node-version: '22.x'
           cache: 'pnpm'
 
       - name: Install dependencies


### PR DESCRIPTION
v1.2.0 Edge publish failed with \`expected non-null body source\` — a Node >=24.14 undici regression hit by publish-browser-extension's Edge upload. Pinning the publish workflow to Node 22. Chrome and Firefox already shipped successfully and will be skipped on re-run via their store-version gates; only Edge will actually publish.

Ref: https://github.com/vercel/next.js/issues/90826